### PR TITLE
Launch conveniences and dependency declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,9 @@ In this demo configuration, the AR3 will be launched using `ros2_control`'s
 `fake_components/GenericSystem` joint loopback simulation. Then, MoveIt2 will
 be launched to plan trajectories and send them to the simulated AR3.
 
-1. Launch the AR3 simulation
+1. Start MoveIt2 with the AR3 simulation
 
-        ros2 launch ar3_bringup ar3_base.launch.py use_fake_hardware:=True
-
-2. Start MoveIt2
-
-        ros2 launch ar3_moveit2_config moveit.launch.py
+        ros2 launch ar3_moveit2_config moveit.launch.py use_fake_hardware:=True
 
 3. In the RVIZ MotionPlanning panel, change the Goal state to "shutdown" and
    click on "Plan & Execute".

--- a/launch/moveit.launch.py
+++ b/launch/moveit.launch.py
@@ -1,27 +1,38 @@
 import os
-import yaml
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, Command
-from launch.conditions import IfCondition, UnlessCondition
-from launch_ros.actions import Node
-from launch.actions import ExecuteProcess
-from ament_index_python.packages import get_package_share_directory
+
 import xacro
+import yaml
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, EmitEvent
+from launch.conditions import IfCondition
+from launch.events import Shutdown
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, Command
+from launch_ros.actions import Node
+
 
 def load_yaml(package_name, *paths):
     package_path = get_package_share_directory(package_name)
     absolute_file_path = os.path.join(package_path, *paths)
 
     try:
-        with open(absolute_file_path, 'r') as file:
+        with open(absolute_file_path, "r") as file:
             return yaml.safe_load(file)
-    except EnvironmentError: # parent of IOError, OSError *and* WindowsError where available
+    except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
 
 def generate_launch_description():
     declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
 
     declared_arguments.append(
         DeclareLaunchArgument(
@@ -31,7 +42,9 @@ def generate_launch_description():
         )
     )
 
-    rviz_config_file_default = os.path.join(get_package_share_directory('ar3_moveit2_config'), 'rviz', 'moveit.rviz')
+    rviz_config_file_default = os.path.join(
+        get_package_share_directory("ar3_moveit2_config"), "rviz", "moveit.rviz"
+    )
     declared_arguments.append(
         DeclareLaunchArgument(
             "rviz_config_file",
@@ -40,24 +53,45 @@ def generate_launch_description():
         )
     )
 
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     start_rviz_0 = LaunchConfiguration("start_rviz_0")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
 
+    declared_arguments.append(
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                [
+                    os.path.join(get_package_share_directory("ar3_bringup"), "launch"),
+                    "/ar3_base.launch.py",
+                ]
+            ),
+            launch_arguments={
+                use_fake_hardware: use_fake_hardware,
+                "start_rviz": "false",
+            }.items(),
+        )
+    )
+
     # planning_context
     robot_description_config = xacro.process_file(
-        os.path.join(get_package_share_directory("ar3_description"),
-                     "urdf", "ar3.urdf.xacro"))
+        os.path.join(
+            get_package_share_directory("ar3_description"), "urdf", "ar3.urdf.xacro"
+        )
+    )
     robot_description = {"robot_description": robot_description_config.toxml()}
 
     # Find and parse SRDF xacro
-    srdf_xacro_path = os.path.join(get_package_share_directory('ar3_moveit2_config'),
-                                   'config', 'ar3_arm.srdf.xacro')
+    srdf_xacro_path = os.path.join(
+        get_package_share_directory("ar3_moveit2_config"),
+        "config",
+        "ar3_arm.srdf.xacro",
+    )
 
-    robot_description_semantic = {'robot_description_semantic' :
-                                  Command(['xacro', ' ', srdf_xacro_path])}
+    robot_description_semantic = {
+        "robot_description_semantic": Command(["xacro", " ", srdf_xacro_path])
+    }
 
-    kinematics_yaml = load_yaml(
-        'ar3_moveit2_config', 'config', 'kinematics.yaml')
+    kinematics_yaml = load_yaml("ar3_moveit2_config", "config", "kinematics.yaml")
     robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
     # Planning Functionality
@@ -68,11 +102,13 @@ def generate_launch_description():
             "start_state_max_bounds_error": 0.1,
         }
     }
-    ompl_planning_yaml = load_yaml('ar3_moveit2_config', 'config', 'ompl_planning.yaml')
-    ompl_planning_pipeline_config['move_group'].update(ompl_planning_yaml)
+    ompl_planning_yaml = load_yaml("ar3_moveit2_config", "config", "ompl_planning.yaml")
+    ompl_planning_pipeline_config["move_group"].update(ompl_planning_yaml)
 
     # Trajectory Execution Functionality
-    moveit_simple_controllers_yaml = load_yaml('ar3_moveit2_config', 'config', 'ar3_controllers.yaml')
+    moveit_simple_controllers_yaml = load_yaml(
+        "ar3_moveit2_config", "config", "ar3_controllers.yaml"
+    )
     moveit_controllers = {
         "moveit_simple_controller_manager": moveit_simple_controllers_yaml,
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
@@ -96,7 +132,7 @@ def generate_launch_description():
     run_move_group_node = Node(
         package="moveit_ros_move_group",
         executable="move_group",
-        output="screen",
+        output="log",
         parameters=[
             robot_description,
             robot_description_semantic,
@@ -121,6 +157,7 @@ def generate_launch_description():
             kinematics_yaml,
         ],
         condition=IfCondition(start_rviz_0),
+        on_exit=EmitEvent(event=Shutdown()),
     )
 
     # Static TF
@@ -132,9 +169,6 @@ def generate_launch_description():
         arguments=["0.0", "0.0", "0.0", "0.0", "0.0", "0.0", "world", "ar3_link0"],
     )
 
-    nodes = [
-        rviz_node,
-        run_move_group_node
-    ]
+    nodes = [rviz_node, run_move_group_node]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/launch/moveit.launch.py
+++ b/launch/moveit.launch.py
@@ -28,6 +28,14 @@ def generate_launch_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
+            "shutdown_with_rviz_exit",
+            default_value="false",
+            description="Emit the shutdown event for the launched system if RViz2 exits."
+        )
+    )
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
             "use_fake_hardware",
             default_value="false",
             description="Start robot with fake hardware mirroring command to its states.",
@@ -53,6 +61,7 @@ def generate_launch_description():
         )
     )
 
+    shutdown_with_rviz_exit = LaunchConfiguration("shutdown_with_rviz_exit")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     start_rviz_0 = LaunchConfiguration("start_rviz_0")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
@@ -132,7 +141,7 @@ def generate_launch_description():
     run_move_group_node = Node(
         package="moveit_ros_move_group",
         executable="move_group",
-        output="log",
+        output="screen",
         parameters=[
             robot_description,
             robot_description_semantic,
@@ -157,7 +166,7 @@ def generate_launch_description():
             kinematics_yaml,
         ],
         condition=IfCondition(start_rviz_0),
-        on_exit=EmitEvent(event=Shutdown()),
+        on_exit=EmitEvent(event=Shutdown(), condition=IfCondition(shutdown_with_rviz_exit)),
     )
 
     # Static TF

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
+  <exec_depend>moveit_visual_tools</exec_depend>
 
   <export>
       <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Here's a patch with two small conveniences when using the launch system. First, the ar3_bringup launch description is automatically included. Second, it's possible to use the launch argument `shutdown_with_rviz_exit` to shutdown the launched system when RViz2 exits, which can be useful when testing and developing. Additionally there two dependencies not missing during the runtime, which are now added.